### PR TITLE
WIP: Variable length decoders

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1061,12 +1061,12 @@ fn generate_write_asm(
     writeln!(out, "    }}").unwrap();
 }
 
-fn word_type_for_width(width: u32) -> &'static str {
+fn word_type_for_width(width: DecoderWidth) -> String {
     match width {
-        8 => "u8",
-        16 => "u16",
-        32 => "u32",
-        _ => "u32",
+        DecoderWidth::Fixed(8) => "u8".to_string(),
+        DecoderWidth::Fixed(16) => "u16".to_string(),
+        DecoderWidth::Fixed(32) => "u32".to_string(),
+        _ => "&[u8]".to_string(),
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -35,7 +35,7 @@ pub fn build_tree(def: &ValidatedDef) -> DecodeNode {
 fn build_node(
     instructions: &[ValidatedInstruction],
     candidates: &[usize],
-    width: u32,
+    width: DecoderWidth,
 ) -> DecodeNode {
     match candidates.len() {
         0 => DecodeNode::Fail,
@@ -163,11 +163,11 @@ fn has_all_fixed_at(instr: &ValidatedInstruction, range: BitRange) -> bool {
 fn find_useful_bit_groups(
     instructions: &[ValidatedInstruction],
     candidates: &[usize],
-    width: u32,
+    width: DecoderWidth,
 ) -> Vec<BitRange> {
-    let mut useful = vec![false; width as usize];
+    let mut useful = vec![false; width.max_bits() as usize];
 
-    for bit in 0..width {
+    for bit in 0..width.max_bits() {
         // Collect fixed values at this bit (skip candidates without fixed bits here)
         let fixed_values: Vec<Bit> = candidates
             .iter()
@@ -184,10 +184,10 @@ fn find_useful_bit_groups(
     // Group contiguous useful bits into ranges
     let mut groups = Vec::new();
     let mut i = 0u32;
-    while i < width {
+    while i < width.max_bits() {
         if useful[i as usize] {
             let start = i;
-            while i < width && useful[i as usize] {
+            while i < width.max_bits() && useful[i as usize] {
                 i += 1;
             }
             let end = i - 1;

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,9 +25,32 @@ pub struct Import {
 #[derive(Debug, Clone)]
 pub struct DecoderConfig {
     pub name: String,
-    pub width: u32,
+    pub width: DecoderWidth,
     pub bit_order: BitOrder,
     pub span: Span,
+}
+
+/// Decoder input width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecoderWidth {
+    Fixed(u32),
+    Variable { min: u32, max: u32 },
+}
+
+impl DecoderWidth {
+    pub fn min_bits(&self) -> u32 {
+        match self {
+            DecoderWidth::Fixed(w) => *w,
+            DecoderWidth::Variable { min, .. } => *min,
+        }
+    }
+    
+    pub fn max_bits(&self) -> u32 {
+        match self {
+            DecoderWidth::Fixed(w) => *w,
+            DecoderWidth::Variable { max, .. } => *max,
+        }
+    }
 }
 
 /// Bit order convention for DSL input.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -210,11 +210,11 @@ fn resolve_types(
 
 fn check_bit_coverage(
     instructions: &[InstructionDef],
-    width: u32,
+    width: DecoderWidth,
     errors: &mut Vec<Error>,
 ) {
     for instr in instructions {
-        let mut covered = vec![false; width as usize];
+        let mut covered = vec![false; width.max_bits() as usize];
 
         for seg in &instr.segments {
             let range = match seg {
@@ -236,7 +236,7 @@ fn check_bit_coverage(
             };
 
             for bit in range.end..=range.start {
-                if bit < width {
+                if bit < width.max_bits() {
                     let idx = bit as usize;
                     if covered[idx] {
                         errors.push(Error::new(
@@ -254,6 +254,7 @@ fn check_bit_coverage(
 
         let missing: Vec<u32> = covered
             .iter()
+            .take(width.min_bits() as usize)
             .enumerate()
             .filter(|&(_, c)| !c)
             .map(|(i, _)| i as u32)


### PR DESCRIPTION
Work in progress of https://github.com/ioncodes/chipi/issues/1

This does not fix code gen, I think the code gen needs to be more stateful (to allow adjusting the body of the emitted tree), or following the last suggestion of the above issue, we need to just move the fixed width decoders over to accepting a fixed width byte slice.

Another conversation can be had about how to inform the caller about the accessed range, so they can easily progress their cursor and decode the next instruction. Not technically required IMO, since the way this DSL operates the resulting instruction variants width will not be ambiguous (I don't think there is a way currently to share an enum variant between multiple instructions with differing widths).