### PR TITLE
fix cpp namespace and format_parser escape bugs

### DIFF
--- a/chipi-core/src/codegen_cpp.rs
+++ b/chipi-core/src/codegen_cpp.rs
@@ -256,49 +256,47 @@ fn emit_display_types(out: &mut String, def: &ValidatedDef, type_maps: &HashMap<
         writeln!(out).unwrap();
     }
 
-    writeln!(out, "}} // namespace {}", to_snake_case(&def.config.name)).unwrap();
-    writeln!(out).unwrap();
-
-    // std::formatter specializations must be outside the namespace
-    if need_signed_hex {
-        let ns = to_snake_case(&def.config.name);
-        writeln!(
-            out,
-            "template <> struct std::formatter<{}::SignedHex> : std::formatter<std::string> {{",
-            ns
-        )
-        .unwrap();
-        writeln!(
-            out,
-            "    auto format({}::SignedHex v, auto& ctx) const {{",
-            ns
-        )
-        .unwrap();
-        writeln!(out, "        if (v.value < 0)").unwrap();
-        writeln!(out, "            return std::formatter<std::string>::format(std::format(\"-0x{{:x}}\", static_cast<unsigned>(-v.value)), ctx);").unwrap();
-        writeln!(out, "        return std::formatter<std::string>::format(std::format(\"0x{{:x}}\", static_cast<unsigned>(v.value)), ctx);").unwrap();
-        writeln!(out, "    }}").unwrap();
-        writeln!(out, "}};").unwrap();
-        writeln!(out).unwrap();
-    }
-
-    if need_hex {
-        let ns = to_snake_case(&def.config.name);
-        writeln!(
-            out,
-            "template <> struct std::formatter<{}::Hex> : std::formatter<std::string> {{",
-            ns
-        )
-        .unwrap();
-        writeln!(out, "    auto format({}::Hex v, auto& ctx) const {{", ns).unwrap();
-        writeln!(out, "        return std::formatter<std::string>::format(std::format(\"0x{{:x}}\", v.value), ctx);").unwrap();
-        writeln!(out, "    }}").unwrap();
-        writeln!(out, "}};").unwrap();
-        writeln!(out).unwrap();
-    }
-
-    // Re-open the namespace
     if need_signed_hex || need_hex {
+        writeln!(out, "}} // namespace {}", to_snake_case(&def.config.name)).unwrap();
+        writeln!(out).unwrap();
+
+        if need_signed_hex {
+            let ns = to_snake_case(&def.config.name);
+            writeln!(
+                out,
+                "template <> struct std::formatter<{}::SignedHex> : std::formatter<std::string> {{",
+                ns
+            )
+            .unwrap();
+            writeln!(
+                out,
+                "    auto format({}::SignedHex v, auto& ctx) const {{",
+                ns
+            )
+            .unwrap();
+            writeln!(out, "        if (v.value < 0)").unwrap();
+            writeln!(out, "            return std::formatter<std::string>::format(std::format(\"-0x{{:x}}\", static_cast<unsigned>(-v.value)), ctx);").unwrap();
+            writeln!(out, "        return std::formatter<std::string>::format(std::format(\"0x{{:x}}\", static_cast<unsigned>(v.value)), ctx);").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "}};").unwrap();
+            writeln!(out).unwrap();
+        }
+
+        if need_hex {
+            let ns = to_snake_case(&def.config.name);
+            writeln!(
+                out,
+                "template <> struct std::formatter<{}::Hex> : std::formatter<std::string> {{",
+                ns
+            )
+            .unwrap();
+            writeln!(out, "    auto format({}::Hex v, auto& ctx) const {{", ns).unwrap();
+            writeln!(out, "        return std::formatter<std::string>::format(std::format(\"0x{{:x}}\", v.value), ctx);").unwrap();
+            writeln!(out, "    }}").unwrap();
+            writeln!(out, "}};").unwrap();
+            writeln!(out).unwrap();
+        }
+
         writeln!(out, "namespace {} {{", to_snake_case(&def.config.name)).unwrap();
         writeln!(out).unwrap();
     }

--- a/chipi-core/src/format_parser.rs
+++ b/chipi-core/src/format_parser.rs
@@ -275,15 +275,29 @@ fn parse_arg_list(input: &str, span: &Span) -> Result<Vec<FormatExpr>, Error> {
 
 /// Find the position of `?` for ternary, not inside parentheses.
 fn find_ternary_question(s: &str) -> Option<usize> {
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0;
     let mut depth = 0;
-    for (i, ch) in s.char_indices() {
-        match ch {
+    let mut byte_pos = 0;
+
+    while i < chars.len() {
+        match chars[i] {
             '(' => depth += 1,
             ')' => depth -= 1,
-            '\\' => continue,
-            '?' if depth == 0 => return Some(i),
+            '\\' => {
+                byte_pos += chars[i].len_utf8();
+                i += 1;
+                if i < chars.len() {
+                    byte_pos += chars[i].len_utf8();
+                }
+                i += 1;
+                continue;
+            }
+            '?' if depth == 0 => return Some(byte_pos),
             _ => {}
         }
+        byte_pos += chars[i].len_utf8();
+        i += 1;
     }
     None
 }


### PR DESCRIPTION
Fixes two small bugs I found:

- `emit_display_types` unconditionally closed the namespace even with no display types existing, so the entire decoder (enum, struct, decode, format) was outside of the namespace. Now only closes/reopens when formatter specialisations actually need to be emitted outside it.
- `find_ternary_question` rewrote to index-based iteration matching the `find_ternary_colon` existing correct pattern.

Thanks for making this project!